### PR TITLE
Add addFromFront

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ console.log(sorted.gt(list, 4)) // returns -1
 Insert a new value into the list sorted.
 Optionally you can use a custom compare function that returns, `compare(a, b)` that returns 1 if `a > b`, 0 if `a === b` and -1 if `a < b`.
 
+#### `sorted.addFromFront(list, value, [compare])`
+
+Inserts a new value (same result as `sorted.add()`) optimized for prepend.
+
 #### `var bool = sorted.remove(list, value, [compare])`
 
 Remove a value. Returns true if the value was in the list.

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 exports.add = add
+exports.addFromFront = addFromFront
 exports.remove = remove
 exports.has = has
 exports.eq = eq
@@ -23,6 +24,18 @@ function add (list, value, cmp) {
     list[top] = list[top - 1]
     list[top - 1] = value
     top--
+  }
+}
+
+function addFromFront (list, value, cmp) {
+  if (!cmp) cmp = defaultCmp
+
+  var top = list.unshift(value) - 1
+
+  for (var i = 0; i < top; i++) {
+    if (cmp(value, list[i + 1]) < 0) return
+    list[i] = list[i + 1]
+    list[i + 1] = value
   }
 }
 

--- a/test.js
+++ b/test.js
@@ -16,6 +16,21 @@ tape('add', function (t) {
   t.end()
 })
 
+tape('addFromFront', function (t) {
+  var list = []
+
+  sorted.addFromFront(list, 3)
+  sorted.addFromFront(list, 4)
+  sorted.addFromFront(list, 3)
+  sorted.addFromFront(list, 9)
+  sorted.addFromFront(list, 0)
+  sorted.addFromFront(list, 5)
+  sorted.addFromFront(list, 8)
+
+  t.same(list, [0, 3, 3, 4, 5, 8, 9])
+  t.end()
+})
+
 tape('remove', function (t) {
   var list = []
 


### PR DESCRIPTION
Adds `addFromFront` which works just like `add` except it starts from the front instead of back.

This can make a big difference in certain situations.  I tested times for adding 99999 descending sorted items.
With `add()`: 30114 ms
With `addFromFront()`: 1351

In my actual use case I use both `add()` (when backfilling old data) and `addFromFront()` (when adding new items; both of which are only approximately sorted).  So it's not always possible to reverse the sort, you may need both.
